### PR TITLE
Add examples for abbreviations

### DIFF
--- a/api-style-guide.md
+++ b/api-style-guide.md
@@ -781,7 +781,7 @@ See [HATEOAS Use Cases](patterns.md#hateoas-use-cases) to find where HATEOAS cou
 <h1 id="naming-conventions">Naming Conventions</h1>
 
 Naming conventions for URIs, query parameters, resources, fields and enums are described in this section. Let us emphasize here that these guidelines are less about following the conventions exactly as described here but they are more about defining some naming conventions and sticking to them in a consistent manner while designing APIs.
-We have [camelCase](https://en.wikipedia.org/wiki/Camel_case) for field and file names.
+We use [camelCase](https://en.wikipedia.org/wiki/Camel_case) for field, file names and query parameters. All abbreviations SHOULD be capitalized (unless a domain wide standard dictates otherwise). If the identifier stards with an abbreviation it MAY be lowercase where appropriate (e.g. such as in field names). Examples: `customerID` ✅, `JSONSchema` ✅, `{ "id": 1 }` ✅, `customerId` 🚫, `JsonSchema` 🚫.
 
 <h2 id="uri-component-names">URI Component Names</h2>
 

--- a/api-style-guide.md
+++ b/api-style-guide.md
@@ -781,7 +781,7 @@ See [HATEOAS Use Cases](patterns.md#hateoas-use-cases) to find where HATEOAS cou
 <h1 id="naming-conventions">Naming Conventions</h1>
 
 Naming conventions for URIs, query parameters, resources, fields and enums are described in this section. Let us emphasize here that these guidelines are less about following the conventions exactly as described here but they are more about defining some naming conventions and sticking to them in a consistent manner while designing APIs.
-We use [camelCase](https://en.wikipedia.org/wiki/Camel_case) for field, file names and query parameters. All abbreviations SHOULD be capitalized (unless a domain wide standard dictates otherwise). If the identifier stards with an abbreviation it MAY be lowercase where appropriate (e.g. such as in field names). Examples: `customerID` ✅, `JSONSchema` ✅, `{ "id": 1 }` ✅, `customerId` 🚫, `JsonSchema` 🚫.
+We use [camelCase](https://en.wikipedia.org/wiki/Camel_case) for fields, file names and query parameters. All abbreviations SHOULD be capitalized (unless a domain wide standard dictates otherwise). If the identifier starts with an abbreviation it MAY be lowercase where appropriate (e.g. such as in field names). Examples: `customerID` ✅, `JSONSchema` ✅, `{ "id": 1 }` ✅, `customerId` 🚫, `JsonSchema` 🚫.
 
 <h2 id="uri-component-names">URI Component Names</h2>
 


### PR DESCRIPTION
Reasons: grammatically correct, better for screen readers.

See https://github.com/airbnb/javascript/#naming--Acronyms-and-Initialisms